### PR TITLE
Fix/audit feedback

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,14 +1,30 @@
-# Environment variables
-PRIVATE_KEY ?= $(shell cat .env | grep PRIVATE_KEY | cut -d '=' -f2)
-CHAIN_1_RPC_URL ?= $(shell cat .env | grep CHAIN_1_RPC_URL | cut -d '=' -f2)
-CHAIN_2_RPC_URL ?= $(shell cat .env | grep CHAIN_2_RPC_URL | cut -d '=' -f2)
+# include .env file and export its env vars
+# (-include to ignore error if it does not exist)
+-include .env
+
+# # Environment variables
+# PRIVATE_KEY ?= $(shell cat .env | grep PRIVATE_KEY | cut -d '=' -f2)
+# EXECUTION_RPC_URL ?= $(shell cat .env | grep EXECUTION_RPC_URL | cut -d '=' -f2)
+# VOTING_RPC_URL ?= $(shell cat .env | grep VOTING_RPC_URL | cut -d '=' -f2)
+
+# # Verifier configuration (set in .env)
+# # EXEC_VERIFIER/VOTING_VERIFIER: one of 'etherscan' or 'blockscout'
+# # If 'blockscout', also set EXEC_BLOCKSCOUT_URL / VOTING_BLOCKSCOUT_URL (without trailing /api)
+# EXEC_VERIFIER ?= $(shell cat .env | grep EXEC_VERIFIER | cut -d '=' -f2)
+# VOTING_VERIFIER ?= $(shell cat .env | grep VOTING_VERIFIER | cut -d '=' -f2)
+# EXEC_BLOCKSCOUT_URL ?= $(shell cat .env | grep EXEC_BLOCKSCOUT_URL | cut -d '=' -f2)
+# VOTING_BLOCKSCOUT_URL ?= $(shell cat .env | grep VOTING_BLOCKSCOUT_URL | cut -d '=' -f2)
+
+# Compute verification flags per chain
+VERIFY_FLAGS_EXEC := $(if $(filter $(EXEC_VERIFIER),blockscout),--verify --verifier blockscout --verifier-url $(EXEC_BLOCKSCOUT_URL)/api,$(if $(filter $(EXEC_VERIFIER),etherscan),--verify,))
+VERIFY_FLAGS_VOTING := $(if $(filter $(VOTING_VERIFIER),blockscout),--verify --verifier blockscout --verifier-url $(VOTING_BLOCKSCOUT_URL)/api,$(if $(filter $(VOTING_VERIFIER),etherscan),--verify,))
 
 # Check if environment variables are set
 check-env:
 	@echo "Checking environment variables..."
 	@if [ -z "$(PRIVATE_KEY)" ]; then echo "ERROR: PRIVATE_KEY not set in .env"; exit 1; fi
-	@if [ -z "$(CHAIN_1_RPC_URL)" ]; then echo "ERROR: CHAIN_1_RPC_URL not set in .env"; exit 1; fi
-	@if [ -z "$(CHAIN_2_RPC_URL)" ]; then echo "ERROR: CHAIN_2_RPC_URL not set in .env"; exit 1; fi
+	@if [ -z "$(EXECUTION_RPC_URL)" ]; then echo "ERROR: EXECUTION_RPC_URL not set in .env"; exit 1; fi
+	@if [ -z "$(VOTING_RPC_URL)" ]; then echo "ERROR: VOTING_RPC_URL not set in .env"; exit 1; fi
 	@echo "Environment variables are properly set"
 
 # Allow scripts to be executed
@@ -30,7 +46,7 @@ install:
 send-tokens:
 	@echo "Sending tokens..."
 	forge script script/BridgeAndSend.s.sol \
-		--rpc-url $(CHAIN_1_RPC_URL) \
+		--rpc-url $(EXECUTION_RPC_URL) \
 		--private-key $(PRIVATE_KEY) \
 		--broadcast \
 		-vvvvv
@@ -39,7 +55,7 @@ send-tokens:
 bridge-tokens:
 	@echo "Bridging tokens..."
 	forge script script/BridgeAndSend.s.sol \
-		--rpc-url $(CHAIN_2_RPC_URL) \
+		--rpc-url $(VOTING_RPC_URL) \
 		--private-key $(PRIVATE_KEY) \
 		--broadcast \
 		-vvvvv
@@ -49,7 +65,7 @@ unstick-deploy-optimism-execution:
 	@echo "Unsticking message on Optimism execution chain..."
 	forge script script/UnstickMessage.s.sol \
 		--sig "unstickDeployOptimismExecution()" \
-		--rpc-url $(CHAIN_2_RPC_URL) \
+		--rpc-url $(VOTING_RPC_URL) \
 		--private-key $(PRIVATE_KEY) \
 		--broadcast \
 		-vvvvv
@@ -59,7 +75,7 @@ unstick-dispatch-arbitrum-execution:
 	@echo "Unsticking dispatch on Arbitrum execution chain..."
 	forge script script/UnstickMessage.s.sol \
 		--sig "unstickDispatchArbitrumExecution()" \
-		--rpc-url $(CHAIN_1_RPC_URL) \
+		--rpc-url $(EXECUTION_RPC_URL) \
 		--private-key $(PRIVATE_KEY) \
 		--broadcast \
 		-vvvvv
@@ -69,7 +85,7 @@ test-oapp-conf:
 	@echo "Testing OApp configuration..."
 	forge script script/BridgeAndSend.s.sol \
 		--sig "testOAppConf()" \
-		--rpc-url $(CHAIN_1_RPC_URL) \
+		--rpc-url $(EXECUTION_RPC_URL) \
 		--private-key $(PRIVATE_KEY) \
 		-vvvvv
 
@@ -78,98 +94,101 @@ set-send-conf-arbitrum:
 	@echo "Setting send configuration for Arbitrum..."
 	forge script script/BridgeAndSend.s.sol \
 		--sig "setSendConfArbitrum()" \
-		--rpc-url $(CHAIN_1_RPC_URL) \
+		--rpc-url $(EXECUTION_RPC_URL) \
 		--private-key $(PRIVATE_KEY) \
 		--broadcast \
 		-vvvvv
 
-# =============================================================================
-# DEPLOYMENT TARGETS
-# =============================================================================
+##################################
+# Deploy Script Helper
+##################################
+define deploy-script
+	export STAGE=$(1) && \
+	export EXECUTION_OR_VOTING=$(2) && \
+	forge script DeployE2E \
+		--rpc-url $(3) \
+		--private-key $(PRIVATE_KEY) \
+		$(4) \
+		-vvvvv
+endef
 
-# Preview deployment stages for execution chain
+###################################################
+### execution (using Etherscan for Verification)
+###
+### If execution is your Execution chain, set (2)=EXECUTION.
+###################################################
+
 preview-deploy-execution-stage-0:
-	@echo "Previewing execution chain deployment stage 0..."
-	forge script script/DeployV2.s.sol --sig "previewDeployExecutionStage0()" --rpc-url $(CHAIN_1_RPC_URL) --private-key $(PRIVATE_KEY) -vvvvv
+	$(call deploy-script,0,EXECUTION,$(EXECUTION_RPC_URL),)
 
 preview-deploy-execution-stage-1:
-	@echo "Previewing execution chain deployment stage 1..."
-	forge script script/DeployV2.s.sol --sig "previewDeployExecutionStage1()" --rpc-url $(CHAIN_1_RPC_URL) --private-key $(PRIVATE_KEY) -vvvvv
+	$(call deploy-script,1,EXECUTION,$(EXECUTION_RPC_URL),)
 
 preview-deploy-execution-stage-2:
-	@echo "Previewing execution chain deployment stage 2..."
-	forge script script/DeployV2.s.sol --sig "previewDeployExecutionStage2()" --rpc-url $(CHAIN_1_RPC_URL) --private-key $(PRIVATE_KEY) -vvvvv
+	$(call deploy-script,2,EXECUTION,$(EXECUTION_RPC_URL),)
 
 preview-deploy-execution-stage-3:
-	@echo "Previewing execution chain deployment stage 3..."
-	forge script script/DeployV2.s.sol --sig "previewDeployExecutionStage3()" --rpc-url $(CHAIN_1_RPC_URL) --private-key $(PRIVATE_KEY) -vvvvv
+	$(call deploy-script,3,EXECUTION,$(EXECUTION_RPC_URL),)
 
 preview-deploy-execution-stage-4:
-	@echo "Previewing execution chain deployment stage 4..."
-	forge script script/DeployV2.s.sol --sig "previewDeployExecutionStage4()" --rpc-url $(CHAIN_1_RPC_URL) --private-key $(PRIVATE_KEY) -vvvvv
+	$(call deploy-script,4,EXECUTION,$(EXECUTION_RPC_URL),)
 
-# Deploy execution chain stages
 deploy-execution-stage-0:
-	@echo "Deploying execution chain stage 0..."
-	forge script script/DeployV2.s.sol --sig "deployExecutionStage0()" --rpc-url $(CHAIN_1_RPC_URL) --private-key $(PRIVATE_KEY) --broadcast --legacy --gas-price 1000000000 -vvvvv
+	$(call deploy-script,0,EXECUTION,$(EXECUTION_RPC_URL),--broadcast --ffi $(VERIFY_FLAGS_EXEC))
 
 deploy-execution-stage-1:
-	@echo "Deploying execution chain stage 1..."
-	forge script script/DeployV2.s.sol --sig "deployExecutionStage1()" --rpc-url $(CHAIN_1_RPC_URL) --private-key $(PRIVATE_KEY) --broadcast --legacy --gas-price 1000000000 -vvvvv
+	$(call deploy-script,1,EXECUTION,$(EXECUTION_RPC_URL),--broadcast $(VERIFY_FLAGS_EXEC))
 
 deploy-execution-stage-2:
-	@echo "Deploying execution chain stage 2..."
-	forge script script/DeployV2.s.sol --sig "deployExecutionStage2()" --rpc-url $(CHAIN_1_RPC_URL) --private-key $(PRIVATE_KEY) --broadcast --legacy --gas-price 1000000000 -vvvvv
+	$(call deploy-script,2,EXECUTION,$(EXECUTION_RPC_URL),--broadcast $(VERIFY_FLAGS_EXEC))
 
 deploy-execution-stage-3:
-	@echo "Deploying execution chain stage 3..."
-	forge script script/DeployV2.s.sol --sig "deployExecutionStage3()" --rpc-url $(CHAIN_1_RPC_URL) --private-key $(PRIVATE_KEY) --broadcast --legacy --gas-price 1000000000 -vvvvv
+	$(call deploy-script,3,EXECUTION,$(EXECUTION_RPC_URL),--broadcast $(VERIFY_FLAGS_EXEC))
 
 deploy-execution-stage-4:
-	@echo "Deploying execution chain stage 4..."
-	forge script script/DeployV2.s.sol --sig "deployExecutionStage4()" --rpc-url $(CHAIN_1_RPC_URL) --private-key $(PRIVATE_KEY) --broadcast --legacy --gas-price 1000000000 -vvvvv
+	$(call deploy-script,4,EXECUTION,${EXECUTION_RPC_URL},--broadcast --verify --etherscan-api-key $(ETHERSCAN_API_KEY))
 
-# Preview deployment stages for voting chain
+
+###################################################
+### voting (using Blockscout for Verification)
+###
+### If voting is your Voting chain, set (2)=VOTING.
+### Blockscout often doesn't strictly need an API key:
+###   --etherscan-api-key $(voting_BLOCKSCOUT_API_KEY)    (optional)
+###################################################
+
 preview-deploy-voting-stage-0:
-	@echo "Previewing voting chain deployment stage 0..."
-	forge script script/DeployV2.s.sol --sig "previewDeployVotingStage0()" --rpc-url $(CHAIN_2_RPC_URL) --private-key $(PRIVATE_KEY) -vvvvv
+	$(call deploy-script,0,VOTING,$(VOTING_RPC_URL),)
 
 preview-deploy-voting-stage-1:
-	@echo "Previewing voting chain deployment stage 1..."
-	forge script script/DeployV2.s.sol --sig "previewDeployVotingStage1()" --rpc-url $(CHAIN_2_RPC_URL) --private-key $(PRIVATE_KEY) -vvvvv
+	$(call deploy-script,1,VOTING,$(VOTING_RPC_URL),)
 
 preview-deploy-voting-stage-2:
-	@echo "Previewing voting chain deployment stage 2..."
-	forge script script/DeployV2.s.sol --sig "previewDeployVotingStage2()" --rpc-url $(CHAIN_2_RPC_URL) --private-key $(PRIVATE_KEY) -vvvvv
+	$(call deploy-script,2,VOTING,$(VOTING_RPC_URL),)
 
 preview-deploy-voting-stage-3:
-	@echo "Previewing voting chain deployment stage 3..."
-	forge script script/DeployV2.s.sol --sig "previewDeployVotingStage3()" --rpc-url $(CHAIN_2_RPC_URL) --private-key $(PRIVATE_KEY) -vvvvv
+	$(call deploy-script,3,VOTING,$(VOTING_RPC_URL),)
 
 preview-deploy-voting-stage-4:
-	@echo "Previewing voting chain deployment stage 4..."
-	forge script script/DeployV2.s.sol --sig "previewDeployVotingStage4()" --rpc-url $(CHAIN_2_RPC_URL) --private-key $(PRIVATE_KEY) -vvvvv
+	$(call deploy-script,4,VOTING,$(VOTING_RPC_URL),)
 
-# Deploy voting chain stages
+# If your Blockscout instance doesn't require an API key, you can omit it.
+# If you do have an API key, append:
+#   --etherscan-api-key $(voting_BLOCKSCOUT_API_KEY)
 deploy-voting-stage-0:
-	@echo "Deploying voting chain stage 0..."
-	forge script script/DeployV2.s.sol --sig "deployVotingStage0()" --rpc-url $(CHAIN_2_RPC_URL) --private-key $(PRIVATE_KEY) --broadcast --legacy --gas-price 1000000000 -vvvvv
+	$(call deploy-script,0,VOTING,$(VOTING_RPC_URL),--broadcast --legacy $(VERIFY_FLAGS_VOTING))
 
 deploy-voting-stage-1:
-	@echo "Deploying voting chain stage 1..."
-	forge script script/DeployV2.s.sol --sig "deployVotingStage1()" --rpc-url $(CHAIN_2_RPC_URL) --private-key $(PRIVATE_KEY) --broadcast --legacy --gas-price 1000000000 -vvvvv
+	$(call deploy-script,1,VOTING,$(VOTING_RPC_URL),--broadcast --legacy $(VERIFY_FLAGS_VOTING))
 
 deploy-voting-stage-2:
-	@echo "Deploying voting chain stage 2..."
-	forge script script/DeployV2.s.sol --sig "deployVotingStage2()" --rpc-url $(CHAIN_2_RPC_URL) --private-key $(PRIVATE_KEY) --broadcast --legacy --gas-price 1000000000 -vvvvv
+	$(call deploy-script,2,VOTING,$(VOTING_RPC_URL),--broadcast --legacy $(VERIFY_FLAGS_VOTING))
 
 deploy-voting-stage-3:
-	@echo "Deploying voting chain stage 3..."
-	forge script script/DeployV2.s.sol --sig "deployVotingStage3()" --rpc-url $(CHAIN_2_RPC_URL) --private-key $(PRIVATE_KEY) --broadcast --legacy --gas-price 1000000000 -vvvvv
+	$(call deploy-script,3,VOTING,$(VOTING_RPC_URL),--broadcast --legacy $(VERIFY_FLAGS_VOTING))
 
 deploy-voting-stage-4:
-	@echo "Deploying voting chain stage 4..."
-	forge script script/DeployV2.s.sol --sig "deployVotingStage4()" --rpc-url $(CHAIN_2_RPC_URL) --private-key $(PRIVATE_KEY) --broadcast --legacy --gas-price 1000000000 -vvvvv
+	$(call deploy-script,4,VOTING,$(VOTING_RPC_URL),--broadcast --legacy $(VERIFY_FLAGS_VOTING))
 
 # =============================================================================
 # L2-TO-L2 SETUP AND TRANSFER TARGETS

--- a/Makefile
+++ b/Makefile
@@ -175,10 +175,10 @@ deploy-voting-stage-4:
 # L2-TO-L2 SETUP AND TRANSFER TARGETS
 # =============================================================================
 
-# Setup L2-to-L2 peer relationships
-setup-l2-to-l2-peers:
-	@echo "Setting up L2-to-L2 peer relationships..."
-	forge script script/SetL2ToL2Peers.s.sol \
+# Setup L2-to-L2 peer relationships (separate runs per chain)
+setup-l2-to-l2-peers-chain1-to-chain2:
+	@echo "Setting Chain 1 bridge peer to Chain 2..."
+	PEER_DIRECTION=0 forge script script/SetL2ToL2Peers.s.sol \
 		--rpc-url $(CHAIN_1_RPC_URL) \
 		--private-key $(PRIVATE_KEY) \
 		--broadcast \
@@ -186,14 +186,39 @@ setup-l2-to-l2-peers:
 		--gas-price 1000000000 \
 		-vvvvv
 
-# Verify L2-to-L2 peer configuration
-verify-l2-to-l2-peers:
-	@echo "Verifying L2-to-L2 peer configuration..."
+setup-l2-to-l2-peers-chain2-to-chain1:
+	@echo "Setting Chain 2 bridge peer to Chain 1..."
+	PEER_DIRECTION=1 forge script script/SetL2ToL2Peers.s.sol \
+		--rpc-url $(CHAIN_2_RPC_URL) \
+		--private-key $(PRIVATE_KEY) \
+		--broadcast \
+		--legacy \
+		--gas-price 1000000000 \
+		-vvvvv
+
+# Composite target to run both directions
+setup-l2-to-l2-peers: setup-l2-to-l2-peers-chain1-to-chain2 setup-l2-to-l2-peers-chain2-to-chain1
+	@echo "L2-to-L2 peer setup (both directions) complete"
+
+# Verify L2-to-L2 peer configuration (per chain) and composite
+verify-l2-to-l2-peers-chain1:
+	@echo "Verifying Chain 1 peer configuration..."
 	forge script script/SetL2ToL2Peers.s.sol \
-		--sig "verifyAllPeers()" \
+		--sig "verifyChain1Peer()" \
 		--rpc-url $(CHAIN_1_RPC_URL) \
 		--private-key $(PRIVATE_KEY) \
 		-vvvvv
+
+verify-l2-to-l2-peers-chain2:
+	@echo "Verifying Chain 2 peer configuration..."
+	forge script script/SetL2ToL2Peers.s.sol \
+		--sig "verifyChain2Peer()" \
+		--rpc-url $(CHAIN_2_RPC_URL) \
+		--private-key $(PRIVATE_KEY) \
+		-vvvvv
+
+verify-l2-to-l2-peers: verify-l2-to-l2-peers-chain1 verify-l2-to-l2-peers-chain2
+	@echo "Verified L2-to-L2 peers on both chains"
 
 # Transfer tokens from Chain 1 to Chain 2
 transfer-chain1-to-chain2:

--- a/Makefile
+++ b/Makefile
@@ -133,6 +133,9 @@ preview-deploy-execution-stage-3:
 preview-deploy-execution-stage-4:
 	$(call deploy-script,4,EXECUTION,$(EXECUTION_RPC_URL),)
 
+preview-deploy-execution-stage-5:
+	$(call deploy-script,5,EXECUTION,$(EXECUTION_RPC_URL),)
+
 deploy-execution-stage-0:
 	$(call deploy-script,0,EXECUTION,$(EXECUTION_RPC_URL),--broadcast --ffi $(VERIFY_FLAGS_EXEC))
 
@@ -148,6 +151,8 @@ deploy-execution-stage-3:
 deploy-execution-stage-4:
 	$(call deploy-script,4,EXECUTION,${EXECUTION_RPC_URL},--broadcast --verify --etherscan-api-key $(ETHERSCAN_API_KEY))
 
+deploy-execution-stage-5:
+	$(call deploy-script,5,EXECUTION,$(EXECUTION_RPC_URL),--broadcast $(VERIFY_FLAGS_EXEC))
 
 ###################################################
 ### voting (using Blockscout for Verification)

--- a/script/DeployV2.s.sol
+++ b/script/DeployV2.s.sol
@@ -97,10 +97,6 @@ contract DeployE2E is Script, SetupExecutionChainE2E, SetupVotingChainE2E {
 
         require(e.base.eid != 0, "ExecutionChain: EID is required");
         require(e.base.lzEndpoint != address(0), "ExecutionChain: LZ endpoint is required");
-        require(
-            e.base.lzEndpoint.code.length > 0,
-            "ExecutionChain: LZ endpoint has no code"
-        );
     }
 
     function setupVotingChain() public view returns (VotingChain memory v) {
@@ -112,10 +108,6 @@ contract DeployE2E is Script, SetupExecutionChainE2E, SetupVotingChainE2E {
 
         require(v.base.eid != 0, "VotingChain: EID is required");
         require(v.base.lzEndpoint != address(0), "VotingChain: LZ endpoint is required");
-        require(
-            v.base.lzEndpoint.code.length > 0,
-            "VotingChain: LZ endpoint has no code"
-        );
     }
 
     function tokenSettingsFromEnv() internal view returns (ToucanVotingSetup.TokenSettings memory ts) {
@@ -265,7 +257,6 @@ contract DeployE2E is Script, SetupExecutionChainE2E, SetupVotingChainE2E {
             revert("ToucanDeployRegistry: entry exists; set ALLOW_OVERWRITE=true");
         }
 
-        require(e.executor != address(0), "ExecutionChain: missing executor");
         _deployOSX(e.base);
         _deployDAOAndMSig(e.base);
         _prepareSetupToucanVoting(e, tokenSettingsFromEnv());
@@ -422,7 +413,6 @@ contract DeployE2E is Script, SetupExecutionChainE2E, SetupVotingChainE2E {
         require(address(e.receiver) != address(0), "ExecutionChain: missing receiver");
         require(address(e.actionRelay) != address(0), "ExecutionChain: missing actionRelay");
         require(address(e.adapter) != address(0), "ExecutionChain: missing adapter");
-        require(e.executor != address(0), "ExecutionChain: missing executor");
     }
 
     // apply installation on the execution chain

--- a/script/DeployV2.s.sol
+++ b/script/DeployV2.s.sol
@@ -94,6 +94,13 @@ contract DeployE2E is Script, SetupExecutionChainE2E, SetupVotingChainE2E {
         e.base.lzEndpoint = vm.envAddress("EXEC_CHAIN_LZ_ENDPOINT");
         e.voter = deployer;
         e.executor = deployer;
+
+        require(e.base.eid != 0, "ExecutionChain: EID is required");
+        require(e.base.lzEndpoint != address(0), "ExecutionChain: LZ endpoint is required");
+        require(
+            e.base.lzEndpoint.code.length > 0,
+            "ExecutionChain: LZ endpoint has no code"
+        );
     }
 
     function setupVotingChain() public view returns (VotingChain memory v) {
@@ -102,6 +109,13 @@ contract DeployE2E is Script, SetupExecutionChainE2E, SetupVotingChainE2E {
         v.base.deployer = deployer;
         v.base.lzEndpoint = vm.envAddress("VOTING_CHAIN_LZ_ENDPOINT");
         v.voter = deployer;
+
+        require(v.base.eid != 0, "VotingChain: EID is required");
+        require(v.base.lzEndpoint != address(0), "VotingChain: LZ endpoint is required");
+        require(
+            v.base.lzEndpoint.code.length > 0,
+            "VotingChain: LZ endpoint has no code"
+        );
     }
 
     function tokenSettingsFromEnv() internal view returns (ToucanVotingSetup.TokenSettings memory ts) {

--- a/script/DeployV2.s.sol
+++ b/script/DeployV2.s.sol
@@ -197,6 +197,8 @@ contract DeployE2E is Script, SetupExecutionChainE2E, SetupVotingChainE2E {
             applyPermissionsExecutionChain();
         } else if (stage == 4) {
             logRegistryExecution();
+        } else if (stage == 5) {
+            copyAndApplyExecutionChain();
         } else {
             revert("Invalid stage");
         }
@@ -525,5 +527,42 @@ contract DeployE2E is Script, SetupExecutionChainE2E, SetupVotingChainE2E {
         );
 
         vm.ffi(inputs);
+    }
+
+    // Stage 5 (Execution chain only):
+    // - Copy the full execution-chain data from an existing deployment ID
+    // - Write it under the current DEPLOYMENT_ID
+    // - Set the VotingChain addresses for this DEPLOYMENT_ID from env
+    // - Apply permissions (stage 3) on the execution chain
+    function copyAndApplyExecutionChain() public requiresRegistry(true) {
+        uint256 fromId = vm.envUint("SOURCE_DEPLOYMENT_ID");
+        require(fromId != 0, "SOURCE_DEPLOYMENT_ID is required");
+
+        // Read source deployment (must have full execution data inc. dao/psp/multisig)
+        ( , ExecutionChain memory srcE) = registryExec.deployments(fromId);
+        require(address(srcE.base.dao) != address(0), "Source exec entry missing DAO");
+        require(address(srcE.base.psp) != address(0), "Source exec entry missing PSP");
+        require(address(srcE.base.multisig) != address(0), "Source exec entry missing multisig");
+
+        // Guard against overwriting an existing init unless allowed
+        if (_existsExecInit(DEPLOYMENT_ID) && !ALLOW_OVERWRITE) {
+            revert("ToucanDeployRegistry: entry exists; set ALLOW_OVERWRITE=true");
+        }
+
+        // Write copied execution-chain under the new DEPLOYMENT_ID
+        registryExec.writeExecutionChain(DEPLOYMENT_ID, srcE);
+
+        // Now set the VotingChain addresses for this DEPLOYMENT_ID on the execution registry
+        address relay = TOUCAN_RELAY;
+        address payable adminXChain = ADMIN_XCHAIN;
+        address bridge = BRIDGE;
+        require(relay != address(0), "COPY: TOUCAN_RELAY required");
+        require(adminXChain != address(0), "COPY: ADMIN_XCHAIN required");
+        require(bridge != address(0), "COPY: BRIDGE required");
+
+        setRequiredXChainContractAddressesExecutionChain(DEPLOYMENT_ID, relay, adminXChain, bridge);
+
+        // Finally, apply permissions (same as stage 3a)
+        applyPermissionsExecutionChain();
     }
 }

--- a/script/DeployV2.s.sol
+++ b/script/DeployV2.s.sol
@@ -67,7 +67,7 @@ contract DeployE2E is Script, SetupExecutionChainE2E, SetupVotingChainE2E {
     address ACTION_RELAY = vm.envAddress("ACTION_RELAY");
     address ADAPTER = vm.envAddress("ADAPTER");
 
-    address EXECUTOR = deployer;
+    // executor is derived from the resolved deployer during broadcast
 
     modifier broadcast() {
         uint256 deployerPrivateKey = vm.envUint("PRIVATE_KEY");
@@ -93,7 +93,7 @@ contract DeployE2E is Script, SetupExecutionChainE2E, SetupVotingChainE2E {
         e.base.deployer = deployer;
         e.base.lzEndpoint = vm.envAddress("EXEC_CHAIN_LZ_ENDPOINT");
         e.voter = deployer;
-        e.executor = EXECUTOR;
+        e.executor = deployer;
     }
 
     function setupVotingChain() public view returns (VotingChain memory v) {
@@ -251,6 +251,7 @@ contract DeployE2E is Script, SetupExecutionChainE2E, SetupVotingChainE2E {
             revert("ToucanDeployRegistry: entry exists; set ALLOW_OVERWRITE=true");
         }
 
+        require(e.executor != address(0), "ExecutionChain: missing executor");
         _deployOSX(e.base);
         _deployDAOAndMSig(e.base);
         _prepareSetupToucanVoting(e, tokenSettingsFromEnv());
@@ -407,6 +408,7 @@ contract DeployE2E is Script, SetupExecutionChainE2E, SetupVotingChainE2E {
         require(address(e.receiver) != address(0), "ExecutionChain: missing receiver");
         require(address(e.actionRelay) != address(0), "ExecutionChain: missing actionRelay");
         require(address(e.adapter) != address(0), "ExecutionChain: missing adapter");
+        require(e.executor != address(0), "ExecutionChain: missing executor");
     }
 
     // apply installation on the execution chain

--- a/script/DeployV2.s.sol
+++ b/script/DeployV2.s.sol
@@ -103,6 +103,13 @@ contract DeployE2E is Script, SetupExecutionChainE2E, SetupVotingChainE2E {
         v.voter = deployer;
     }
 
+    function tokenSettingsFromEnv() internal view returns (ToucanVotingSetup.TokenSettings memory ts) {
+        address tokenAddr = vm.envOr("EXEC_TOKEN_ADDR", address(0));
+        string memory tokenName = vm.envOr("EXEC_TOKEN_NAME", string("Lightlink Governance"));
+        string memory tokenSymbol = vm.envOr("EXEC_TOKEN_SYMBOL", string("LLG"));
+        ts = ToucanVotingSetup.TokenSettings({addr: tokenAddr, name: tokenName, symbol: tokenSymbol});
+    }
+
     function _isOnExecutionChain() internal view returns (bool) {
         string memory result = vm.envString("EXECUTION_OR_VOTING");
         if (keccak256(abi.encodePacked(result)) == keccak256(abi.encodePacked("EXECUTION"))) {
@@ -207,7 +214,7 @@ contract DeployE2E is Script, SetupExecutionChainE2E, SetupVotingChainE2E {
 
         _deployOSX(e.base);
         _deployDAOAndMSig(e.base);
-        _prepareSetupToucanVoting(e);
+        _prepareSetupToucanVoting(e, tokenSettingsFromEnv());
         _prepareSetupReceiver(e);
 
         registryExec.writeExecutionChain(DEPLOYMENT_ID, e);

--- a/script/DeployV2.s.sol
+++ b/script/DeployV2.s.sol
@@ -49,7 +49,8 @@ contract DeployE2E is Script, SetupExecutionChainE2E, SetupVotingChainE2E {
     // deployer will receive the tokens on execution chain
     address deployer;
 
-    uint256 DEPLOYMENT_ID = 6;
+    uint256 DEPLOYMENT_ID = vm.envUint("DEPLOYMENT_ID");
+    bool ALLOW_OVERWRITE = vm.envOr("ALLOW_OVERWRITE", false);
 
     ToucanDeployRegistry registryVot = ToucanDeployRegistry(vm.envAddress("REGISTRY_VOT"));
     ToucanDeployRegistry registryExec = ToucanDeployRegistry(vm.envAddress("REGISTRY_EXEC"));
@@ -123,10 +124,44 @@ contract DeployE2E is Script, SetupExecutionChainE2E, SetupVotingChainE2E {
         }
     }
 
+    function _existsExecInit(uint256 id) internal view returns (bool) {
+        (, ExecutionChain memory ec) = registryExec.deployments(id);
+        return ec.base.eid != 0;
+    }
+
+    function _existsExecVotingPart(uint256 id) internal view returns (bool) {
+        (VotingChain memory vc, ) = registryExec.deployments(id);
+        return (
+            vc.base.eid != 0 ||
+            address(vc.relay) != address(0) ||
+            address(vc.adminXChain) != address(0) ||
+            address(vc.bridge) != address(0)
+        );
+    }
+
+    function _existsVotInit(uint256 id) internal view returns (bool) {
+        (VotingChain memory vc, ) = registryVot.deployments(id);
+        return vc.base.eid != 0;
+    }
+
+    function _existsVotExecPart(uint256 id) internal view returns (bool) {
+        (, ExecutionChain memory ec) = registryVot.deployments(id);
+        return (
+            ec.base.eid != 0 ||
+            address(ec.receiver) != address(0) ||
+            address(ec.actionRelay) != address(0) ||
+            address(ec.adapter) != address(0)
+        );
+    }
+
     function run() public broadcast {
         // set env vars
         uint stage = vm.envUint("STAGE");
         bool isOnExecutionChain = _isOnExecutionChain();
+
+        require(DEPLOYMENT_ID != 0, "DEPLOYMENT_ID must be non-zero");
+        console2.log("DEPLOYMENT_ID: %s", DEPLOYMENT_ID);
+        console2.log("ALLOW_OVERWRITE: %s", ALLOW_OVERWRITE);
 
         // enter the switch for each chain
         if (isOnExecutionChain) {
@@ -212,6 +247,10 @@ contract DeployE2E is Script, SetupExecutionChainE2E, SetupVotingChainE2E {
             console2.log("REGISTRY: %s", address(registryExec));
         }
 
+        if (_existsExecInit(DEPLOYMENT_ID) && !ALLOW_OVERWRITE) {
+            revert("ToucanDeployRegistry: entry exists; set ALLOW_OVERWRITE=true");
+        }
+
         _deployOSX(e.base);
         _deployDAOAndMSig(e.base);
         _prepareSetupToucanVoting(e, tokenSettingsFromEnv());
@@ -225,6 +264,10 @@ contract DeployE2E is Script, SetupExecutionChainE2E, SetupVotingChainE2E {
             console2.log("REGISTRY NOT FOUND, creating new one");
             registryVot = new ToucanDeployRegistry();
             console2.log("REGISTRY: %s", address(registryVot));
+        }
+
+        if (_existsVotInit(DEPLOYMENT_ID) && !ALLOW_OVERWRITE) {
+            revert("ToucanDeployRegistry: entry exists; set ALLOW_OVERWRITE=true");
         }
 
         // grab the basic execution chain
@@ -297,6 +340,10 @@ contract DeployE2E is Script, SetupExecutionChainE2E, SetupVotingChainE2E {
         require(adminXChain != address(0), "AdminXChain address is required");
         require(bridge != address(0), "Bridge address is required");
 
+        if (_existsExecVotingPart(id) && !ALLOW_OVERWRITE) {
+            revert("ToucanDeployRegistry: voting entry exists; set ALLOW_OVERWRITE=true");
+        }
+
         VotingChain memory vc = setupVotingChain();
         vc.relay = ToucanRelay(relay);
         vc.adminXChain = AdminXChain(adminXChain);
@@ -316,6 +363,10 @@ contract DeployE2E is Script, SetupExecutionChainE2E, SetupVotingChainE2E {
         require(receiver != address(0), "Receiver address is required");
         require(actionRelay != address(0), "ActionRelay address is required");
         require(adapter != address(0), "Adapter address is required");
+
+        if (_existsVotExecPart(id) && !ALLOW_OVERWRITE) {
+            revert("ToucanDeployRegistry: execution entry exists; set ALLOW_OVERWRITE=true");
+        }
 
         ExecutionChain memory ec = setupExecutionChain();
         ec.receiver = ToucanReceiver(receiver);
@@ -391,6 +442,7 @@ contract DeployE2E is Script, SetupExecutionChainE2E, SetupVotingChainE2E {
     function logRegistryExecution() public view requiresRegistry(true) {
         (VotingChain memory v, ExecutionChain memory e) = registryExec.deployments(DEPLOYMENT_ID);
 
+        console2.log("DEPLOYMENT_ID: %s", DEPLOYMENT_ID);
         console2.log("ExecutionChain:");
         console2.log("  chainName: %s", e.base.chainName);
         console2.log("  eid: %s", e.base.eid);
@@ -419,6 +471,7 @@ contract DeployE2E is Script, SetupExecutionChainE2E, SetupVotingChainE2E {
     function logRegistryVoting() public view requiresRegistry(false) {
         (VotingChain memory v, ExecutionChain memory e) = registryVot.deployments(DEPLOYMENT_ID);
 
+        console2.log("DEPLOYMENT_ID: %s", DEPLOYMENT_ID);
         console2.log("VotingChain:");
         console2.log("  chainName: %s", v.base.chainName);
         console2.log("  eid: %s", v.base.eid);

--- a/script/DeployV2.s.sol
+++ b/script/DeployV2.s.sol
@@ -469,6 +469,7 @@ contract DeployE2E is Script, SetupExecutionChainE2E, SetupVotingChainE2E {
 
         console2.log("DAO and Contracts");
         console2.log("  dao: %s", address(e.base.dao));
+        console2.log("  psp: %s", address(e.base.psp));
         console2.log("  toucanVoting: %s", address(e.voting));
         console2.log("  receiver: %s", address(e.receiver));
         console2.log("  actionRelay: %s", address(e.actionRelay));
@@ -496,6 +497,7 @@ contract DeployE2E is Script, SetupExecutionChainE2E, SetupVotingChainE2E {
 
         console2.log("DAO and Contracts");
         console2.log("  dao: %s", address(v.base.dao));
+        console2.log("  psp: %s", address(v.base.psp));
         console2.log("  relay: %s", address(v.relay));
         console2.log("  adminXChain: %s", address(v.adminXChain));
         console2.log("  bridge: %s", address(v.bridge));

--- a/script/SetL2ToL2Peers.s.sol
+++ b/script/SetL2ToL2Peers.s.sol
@@ -47,6 +47,12 @@ contract SetL2ToL2Peers is Script {
         address chain1Multisig = vm.envAddress("CHAIN_1_MULTISIG");
         address chain2Bridge = vm.envAddress("CHAIN_2_BRIDGE");
         uint32 chain2Eid = uint32(vm.envUint("CHAIN_2_EID"));
+        uint32 chain1Eid = uint32(vm.envUint("CHAIN_1_EID"));
+        
+        require(chain1Bridge != address(0) && chain2Bridge != address(0), "invalid bridge");
+        require(chain1Dao != address(0) && chain1Multisig != address(0), "invalid dao/multisig");
+        require(chain1Psp != address(0), "invalid PSP");
+        require(chain1Eid != 0 && chain2Eid != 0, "invalid EID");
         
         console2.log("Chain 1 Bridge:", chain1Bridge);
         console2.log("Chain 2 Bridge:", chain2Bridge);
@@ -92,6 +98,12 @@ contract SetL2ToL2Peers is Script {
         address chain2Multisig = vm.envAddress("CHAIN_2_MULTISIG");
         address chain1Bridge = vm.envAddress("CHAIN_1_BRIDGE");
         uint32 chain1Eid = uint32(vm.envUint("CHAIN_1_EID"));
+        uint32 chain2Eid = uint32(vm.envUint("CHAIN_2_EID"));
+        
+        require(chain2Bridge != address(0) && chain1Bridge != address(0), "invalid bridge");
+        require(chain2Dao != address(0) && chain2Multisig != address(0), "invalid dao/multisig");
+        require(chain2Psp != address(0), "invalid PSP");
+        require(chain1Eid != 0 && chain2Eid != 0, "invalid EID");
         
         console2.log("Chain 2 Bridge:", chain2Bridge);
         console2.log("Chain 1 Bridge:", chain1Bridge);

--- a/script/SetL2ToL2Peers.s.sol
+++ b/script/SetL2ToL2Peers.s.sol
@@ -24,15 +24,17 @@ contract SetL2ToL2Peers is Script {
     }
     
     function run() public broadcast {
-        console2.log("Setting up L2-to-L2 peer relationships for governance token transfers");
-        
-        // Step 1: Set Chain 1 bridge to communicate with Chain 2
-        // setChain1ToChain2Peer();
-        
-        // Step 2: Set Chain 2 bridge to communicate with Chain 1
-        setChain2ToChain1Peer();
-        
-        console2.log("L2-to-L2 peer setup complete!");
+        uint256 direction = vm.envUint("PEER_DIRECTION");
+
+        if (direction == 0) {
+            console2.log("Setting up Chain 1 -> Chain 2 peer");
+            setChain1ToChain2Peer();
+        } else if (direction == 1) {
+            console2.log("Setting up Chain 2 -> Chain 1 peer");
+            setChain2ToChain1Peer();
+        } else {
+            revert("PEER_DIRECTION must be 0 (CHAIN1_TO_CHAIN2) or 1 (CHAIN2_TO_CHAIN1)");
+        }
     }
     
     function setChain1ToChain2Peer() public {

--- a/src/e2e/E2ESetup.sol
+++ b/src/e2e/E2ESetup.sol
@@ -195,6 +195,64 @@ contract SetupExecutionChainE2E is SetupE2EBase {
         chain.token = GovernanceERC20(helpers[0]);
     }
 
+    function _prepareSetupToucanVoting(
+        ExecutionChain memory chain,
+        ToucanVotingSetup.TokenSettings memory tokenSettings
+    ) internal {
+        GovernanceERC20.MintSettings memory mintSettings = GovernanceERC20.MintSettings(
+            new address[](1),
+            new uint256[](1)
+        );
+        mintSettings.receivers[0] = address(this);
+        mintSettings.amounts[0] = 0;
+
+        GovernanceERC20 baseToken = new GovernanceERC20(
+            IDAO(address(chain.base.dao)),
+            "Test Token",
+            "TT",
+            mintSettings
+        );
+
+        chain.votingSetup = new ToucanVotingSetup(
+            new ToucanVoting(),
+            baseToken,
+            new GovernanceWrappedERC20(
+                IERC20Upgradeable(address(baseToken)),
+                "Wrapped Test Token",
+                "WTT"
+            )
+        );
+
+        chain.base.psp.queueSetup(address(chain.votingSetup));
+
+        IToucanVoting.VotingSettings memory votingSettings = IToucanVoting.VotingSettings({
+            votingMode: IToucanVoting.VotingMode.VoteReplacement,
+            supportThreshold: 1e5,
+            minParticipation: 1e5,
+            minDuration: 2 hours,
+            minProposerVotingPower: 1 ether
+        });
+
+        mintSettings.receivers[0] = chain.voter;
+        mintSettings.amounts[0] = 0;
+
+        bytes memory data = abi.encode(votingSettings, tokenSettings, mintSettings, false);
+
+        (
+            address votingPluginAddress,
+            IPluginSetup.PreparedSetupData memory votingPluginPreparedSetupData
+        ) = chain.base.psp.prepareInstallation(
+                address(chain.base.dao),
+                _mockPrepareInstallationParams(data)
+            );
+
+        chain.votingPermissions = votingPluginPreparedSetupData.permissions;
+
+        chain.voting = ToucanVoting(votingPluginAddress);
+        address[] memory helpers = votingPluginPreparedSetupData.helpers;
+        chain.token = GovernanceERC20(helpers[0]);
+    }
+
     function _prepareSetupReceiver(ExecutionChain memory chain) internal {
         // deploy receiver and set it as next address for PSP to use
         chain.receiverSetup = new ToucanReceiverSetup(


### PR DESCRIPTION
This pull request refactors the deployment and environment configuration for the project, focusing on improving flexibility, maintainability, and safety for multi-chain deployments. The changes standardize environment variable usage, introduce more robust deployment controls, and modularize deployment logic for both execution and voting chains.

**Key changes include:**

### Makefile improvements and environment variable standardization

* Switched from hardcoded environment variable extraction to using `-include .env` for automatic environment variable loading, and replaced old variable names (`CHAIN_1_RPC_URL`, `CHAIN_2_RPC_URL`) with `EXECUTION_RPC_URL` and `VOTING_RPC_URL` throughout the `Makefile`. [[1]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L1-R27) [[2]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L33-R49) [[3]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L42-R58) [[4]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L52-R68) [[5]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L62-R78) [[6]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L72-R88) [[7]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L81-R241)
* Added logic to compute verification flags for Etherscan and Blockscout based on `.env` configuration, making contract verification more flexible and chain-specific.
* Modularized deployment targets using a `deploy-script` Makefile macro, reducing duplication and making it easier to add or modify deployment stages for execution and voting chains.
* Improved L2-to-L2 peer setup and verification by splitting them into per-chain targets and adding composite targets for both directions, increasing clarity and control.

### Deployment script (`DeployE2E`) enhancements

* Made `DEPLOYMENT_ID` and `ALLOW_OVERWRITE` configurable via environment variables, adding checks to prevent accidental overwrites of existing deployments unless explicitly allowed. [[1]](diffhunk://#diff-dc93728aa36beecbb02fd3a478bda94a4c8e14aa2856d941d14affcbb8811d87L52-R53) [[2]](diffhunk://#diff-dc93728aa36beecbb02fd3a478bda94a4c8e14aa2856d941d14affcbb8811d87R141-R179) [[3]](diffhunk://#diff-dc93728aa36beecbb02fd3a478bda94a4c8e14aa2856d941d14affcbb8811d87R264-R271) [[4]](diffhunk://#diff-dc93728aa36beecbb02fd3a478bda94a4c8e14aa2856d941d14affcbb8811d87R284-R287) [[5]](diffhunk://#diff-dc93728aa36beecbb02fd3a478bda94a4c8e14aa2856d941d14affcbb8811d87R358-R361) [[6]](diffhunk://#diff-dc93728aa36beecbb02fd3a478bda94a4c8e14aa2856d941d14affcbb8811d87R382-R385)
* Added existence checks for execution and voting chain deployment records in the registry, with informative error messages and overwrite protection. [[1]](diffhunk://#diff-dc93728aa36beecbb02fd3a478bda94a4c8e14aa2856d941d14affcbb8811d87R141-R179) [[2]](diffhunk://#diff-dc93728aa36beecbb02fd3a478bda94a4c8e14aa2856d941d14affcbb8811d87R264-R271) [[3]](diffhunk://#diff-dc93728aa36beecbb02fd3a478bda94a4c8e14aa2856d941d14affcbb8811d87R284-R287) [[4]](diffhunk://#diff-dc93728aa36beecbb02fd3a478bda94a4c8e14aa2856d941d14affcbb8811d87R358-R361) [[5]](diffhunk://#diff-dc93728aa36beecbb02fd3a478bda94a4c8e14aa2856d941d14affcbb8811d87R382-R385)
* Improved environment validation and error handling in `setupExecutionChain` and `setupVotingChain`, including required fields and contract code presence checks. [[1]](diffhunk://#diff-dc93728aa36beecbb02fd3a478bda94a4c8e14aa2856d941d14affcbb8811d87L69-R70) [[2]](diffhunk://#diff-dc93728aa36beecbb02fd3a478bda94a4c8e14aa2856d941d14affcbb8811d87L95-R103) [[3]](diffhunk://#diff-dc93728aa36beecbb02fd3a478bda94a4c8e14aa2856d941d14affcbb8811d87R112-R125) [[4]](diffhunk://#diff-dc93728aa36beecbb02fd3a478bda94a4c8e14aa2856d941d14affcbb8811d87R425)
* Added a helper to fetch token settings from environment variables, supporting custom token address, name, and symbol for deployments.

### Deploying new chain
Added a new execution-only Stage 5 to the deployment script. This stage copies an existing execution deployment from SOURCE_DEPLOYMENT_ID into a new DEPLOYMENT_ID, wires in the voting-chain peers (TOUCAN_RELAY, ADMIN_XCHAIN, BRIDGE), and automatically applies permissions (equivalent to Stage 3). It performs no new deployments and is intended for reusing an already-deployed execution stack when rolling out to a second chain.
